### PR TITLE
day 11

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,7 +19,8 @@
     "./day_7/Cargo.toml",
     "./day_8/Cargo.toml",
     "./day_9/Cargo.toml",
-    "./day_10/Cargo.toml"
+    "./day_10/Cargo.toml",
+    "./day_11/Cargo.toml"
   ],
   "rust-analyzer.rustfmt.extraArgs": [
     "--config",

--- a/day_10/src/part1_mod.rs
+++ b/day_10/src/part1_mod.rs
@@ -20,7 +20,7 @@ impl ProblemSolver for ProblemSolverPattern {
   fn initialize(lines: impl Iterator<Item = String>) -> Self::Input {
     let commands: Vec<(String, Option<i32>)> = lines
       .enumerate()
-      .map(|(h, l)| interpret_command(l))
+      .map(|(h, l)| interpret_command(h, l))
       .collect();
 
     Self::Input { commands }

--- a/day_11/Cargo.toml
+++ b/day_11/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "day_11"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+sscanf = "0.4.1"
+
+[[bin]]
+name="part1"
+path="src/part1.rs"
+
+[[bin]]
+name="part2"
+path="src/part2.rs"

--- a/day_11/input.txt
+++ b/day_11/input.txt
@@ -1,0 +1,55 @@
+Monkey 0:
+  Starting items: 52, 60, 85, 69, 75, 75
+  Operation: new = old * 17
+  Test: divisible by 13
+    If true: throw to monkey 6
+    If false: throw to monkey 7
+
+Monkey 1:
+  Starting items: 96, 82, 61, 99, 82, 84, 85
+  Operation: new = old + 8
+  Test: divisible by 7
+    If true: throw to monkey 0
+    If false: throw to monkey 7
+
+Monkey 2:
+  Starting items: 95, 79
+  Operation: new = old + 6
+  Test: divisible by 19
+    If true: throw to monkey 5
+    If false: throw to monkey 3
+
+Monkey 3:
+  Starting items: 88, 50, 82, 65, 77
+  Operation: new = old * 19
+  Test: divisible by 2
+    If true: throw to monkey 4
+    If false: throw to monkey 1
+
+Monkey 4:
+  Starting items: 66, 90, 59, 90, 87, 63, 53, 88
+  Operation: new = old + 7
+  Test: divisible by 5
+    If true: throw to monkey 1
+    If false: throw to monkey 0
+
+Monkey 5:
+  Starting items: 92, 75, 62
+  Operation: new = old * old
+  Test: divisible by 3
+    If true: throw to monkey 3
+    If false: throw to monkey 4
+
+Monkey 6:
+  Starting items: 94, 86, 76, 67
+  Operation: new = old + 1
+  Test: divisible by 11
+    If true: throw to monkey 5
+    If false: throw to monkey 2
+
+Monkey 7:
+  Starting items: 57
+  Operation: new = old + 2
+  Test: divisible by 17
+    If true: throw to monkey 6
+    If false: throw to monkey 2

--- a/day_11/sample.txt
+++ b/day_11/sample.txt
@@ -1,0 +1,27 @@
+Monkey 0:
+  Starting items: 79, 98
+  Operation: new = old * 19
+  Test: divisible by 23
+    If true: throw to monkey 2
+    If false: throw to monkey 3
+
+Monkey 1:
+  Starting items: 54, 65, 75, 74
+  Operation: new = old + 6
+  Test: divisible by 19
+    If true: throw to monkey 2
+    If false: throw to monkey 0
+
+Monkey 2:
+  Starting items: 79, 60, 97
+  Operation: new = old * old
+  Test: divisible by 13
+    If true: throw to monkey 1
+    If false: throw to monkey 3
+
+Monkey 3:
+  Starting items: 74
+  Operation: new = old + 3
+  Test: divisible by 17
+    If true: throw to monkey 0
+    If false: throw to monkey 1

--- a/day_11/src/common.rs
+++ b/day_11/src/common.rs
@@ -1,0 +1,85 @@
+use sscanf::sscanf;
+use std::collections::VecDeque;
+
+
+#[derive(Clone)]
+pub struct Monkey {
+  pub test: i32,
+  pub result: (usize, usize),
+  pub operation: (char, i32),
+}
+
+impl Monkey {
+  pub fn input_props_from(record: Vec<String>) -> (VecDeque<i32>, Monkey) {
+    let invalid_format_error =
+      &format!("invalid record format for monkey:\n{}", record.join("\n"));
+    assert!(record.len() > 5, "{}", invalid_format_error);
+
+    let (_, items_str) = sscanf!(record[1], r"{str:/[^:]+:\s+/}{str}")
+      .expect(invalid_format_error);
+    let items = items_str
+      .trim()
+      .split(", ")
+      .map(|v| v.parse::<i32>().unwrap())
+      .collect();
+
+    let o = record[2]
+      .split_whitespace()
+      .collect::<Vec<&str>>()
+      .as_slice()
+      .chunks(2)
+      .last()
+      .unwrap_or(&[])
+      .to_vec();
+    let operation = (
+      o[0].chars().next().unwrap(),
+      o[1].parse::<i32>().unwrap_or(i32::MAX),
+    );
+    let (_, test) = sscanf!(record[3], r"{str:/.*\s/}{i32:/\d+$/}")
+      .expect(invalid_format_error);
+    let result = (
+      sscanf!(record[5], r"{str:/.*\s/}{usize:/\d+$/}")
+        .expect(invalid_format_error)
+        .1,
+      sscanf!(record[4], r"{str:/.*\s/}{usize:/\d+$/}")
+        .expect(invalid_format_error)
+        .1,
+    );
+
+    (items, Monkey { test, result, operation })
+  }
+}
+
+pub fn convert_vec_to_vec_and_vec<T, U>(vec: Vec<(T, U)>) -> (Vec<T>, Vec<U>) {
+  let mut vec_deques = Vec::new();
+  let mut monkeys = Vec::new();
+
+  for (vec_deque, monkey) in vec {
+    vec_deques.push(vec_deque);
+    monkeys.push(monkey);
+  }
+
+  (vec_deques, monkeys)
+}
+
+const MODULUS: i32 = 46340; // Square root of i32::MAX
+pub fn modular_reduction(mut value: i32) -> i32 {
+  // Apply modulus operation
+  value %= MODULUS;
+
+  // Apply signed modular arithmetic
+  let midpoint = MODULUS / 2;
+  if value >= midpoint {
+    value -= MODULUS;
+  }
+
+  value
+}
+
+pub fn inv_heaviside(x: i32) -> i32 {
+  if x <= 0 {
+    1
+  } else {
+    0
+  }
+}

--- a/day_11/src/common.rs
+++ b/day_11/src/common.rs
@@ -1,16 +1,16 @@
 use sscanf::sscanf;
-use std::collections::VecDeque;
+use std::collections::{BinaryHeap, VecDeque};
 
 
 #[derive(Clone)]
 pub struct Monkey {
-  pub test: i32,
+  pub test: i64,
   pub result: (usize, usize),
-  pub operation: (char, i32),
+  pub operation: (char, i64),
 }
 
 impl Monkey {
-  pub fn input_props_from(record: Vec<String>) -> (VecDeque<i32>, Monkey) {
+  pub fn input_props_from(record: Vec<String>) -> (VecDeque<i64>, Monkey) {
     let invalid_format_error =
       &format!("invalid record format for monkey:\n{}", record.join("\n"));
     assert!(record.len() > 5, "{}", invalid_format_error);
@@ -20,7 +20,7 @@ impl Monkey {
     let items = items_str
       .trim()
       .split(", ")
-      .map(|v| v.parse::<i32>().unwrap())
+      .map(|v| v.parse::<i64>().unwrap())
       .collect();
 
     let o = record[2]
@@ -33,9 +33,9 @@ impl Monkey {
       .to_vec();
     let operation = (
       o[0].chars().next().unwrap(),
-      o[1].parse::<i32>().unwrap_or(i32::MAX),
+      o[1].parse::<i64>().unwrap_or(i64::MAX),
     );
-    let (_, test) = sscanf!(record[3], r"{str:/.*\s/}{i32:/\d+$/}")
+    let (_, test) = sscanf!(record[3], r"{str:/.*\s/}{i64:/\d+$/}")
       .expect(invalid_format_error);
     let result = (
       sscanf!(record[5], r"{str:/.*\s/}{usize:/\d+$/}")
@@ -47,6 +47,39 @@ impl Monkey {
     );
 
     (items, Monkey { test, result, operation })
+  }
+
+  pub fn inspect_items<R>(
+    &mut self,
+    items: &VecDeque<i64>,
+    relief: R,
+  ) -> Vec<(usize, i64)>
+  where
+    R: Fn(i64) -> i64,
+  {
+    let mut actions: Vec<(usize, i64)> = Vec::new();
+    for item in items.iter() {
+      let updated_item = match self.operation.0 {
+        '+' => item + self.operation.1,
+        '*' => {
+          let r = match self.operation.1 {
+            i64::MAX => *item,
+            x => x,
+          };
+          item * r
+        }
+        _ => unimplemented!(),
+      };
+      let updated_item = relief(updated_item);
+      let to = match inv_heaviside(updated_item % self.test) {
+        0 => self.result.0,
+        1 => self.result.1,
+        x => panic!("{}", x),
+      };
+      actions.push((to, updated_item));
+    }
+
+    actions
   }
 }
 
@@ -62,21 +95,35 @@ pub fn convert_vec_to_vec_and_vec<T, U>(vec: Vec<(T, U)>) -> (Vec<T>, Vec<U>) {
   (vec_deques, monkeys)
 }
 
-const MODULUS: i32 = 46340; // Square root of i32::MAX
-pub fn modular_reduction(mut value: i32) -> i32 {
-  // Apply modulus operation
-  value %= MODULUS;
+pub fn factory_ordered_troup_tallies<R>(
+  mut monkeys: Vec<Monkey>,
+  mut items: Vec<VecDeque<i64>>,
+  rounds: usize,
+  relief: R,
+) -> BinaryHeap<usize>
+where
+  R: Fn(i64) -> i64 + Copy,
+{
+  let rates = (0..rounds).fold(vec![0; monkeys.len()], |mut acc, _| {
+    // Move closure
+    for (index, monkey) in monkeys.iter_mut().enumerate() {
+      let actions = monkey.inspect_items(&items[index], relief);
+      acc[index] += items[index].len();
+      actions.iter().for_each(|(to, value)| {
+        println!("@{}  {}:{}", index, to, *value);
+        items[*to].push_front(*value);
+        items[index].pop_back();
+      });
+      items[index].clear();
+    }
+    dbg!(acc.clone());
+    acc
+  });
 
-  // Apply signed modular arithmetic
-  let midpoint = MODULUS / 2;
-  if value >= midpoint {
-    value -= MODULUS;
-  }
-
-  value
+  BinaryHeap::from(rates)
 }
 
-pub fn inv_heaviside(x: i32) -> i32 {
+pub fn inv_heaviside(x: i64) -> i64 {
   if x <= 0 {
     1
   } else {

--- a/day_11/src/part1.rs
+++ b/day_11/src/part1.rs
@@ -1,0 +1,10 @@
+mod part1_module;
+use part1_module::ProblemSolverPattern;
+mod problem_solver;
+use problem_solver::solve_problem;
+mod common;
+
+
+fn main() {
+  solve_problem::<ProblemSolverPattern>();
+}

--- a/day_11/src/part1_module.rs
+++ b/day_11/src/part1_module.rs
@@ -1,0 +1,100 @@
+use std::collections::BinaryHeap;
+use std::collections::VecDeque;
+
+use super::common::*;
+use super::problem_solver::ProblemSolver;
+
+
+const ROUNDS: usize = 20;
+const RELIEF: i32 = 3;
+
+pub struct PSInput {
+  monkeys: Vec<Monkey>,
+  items: Vec<VecDeque<i32>>, // separate because iterating each monkey we must mutate each other's items. assignment there requires a double borrow if from monkey.items
+}
+
+pub struct PSSolution {
+  monkey_business: i32,
+}
+
+pub struct ProblemSolverPattern;
+
+impl ProblemSolver for ProblemSolverPattern {
+  type Input = PSInput;
+  type Solution = PSSolution;
+
+  fn initialize(lines: impl Iterator<Item = String>) -> Self::Input {
+    let (items, monkeys): (Vec<VecDeque<i32>>, Vec<Monkey>) =
+      convert_vec_to_vec_and_vec(
+        lines
+          .collect::<Vec<String>>()
+          .chunks(7)
+          .map(|record| Monkey::input_props_from(record.to_vec()))
+          .collect(),
+      );
+
+    PSInput { monkeys, items }
+  }
+
+  fn solve(input: Self::Input) -> Self::Solution {
+    let mut monkeys = input.monkeys;
+    let mut items = input.items;
+
+    let rates = (0..ROUNDS).fold(vec![0; monkeys.len()], |mut acc, _| {
+      // Move closure
+      for (index, monkey) in monkeys.iter_mut().enumerate() {
+        let actions = monkey.inspect_items(&items[index], RELIEF);
+        acc[index] += items[index].len();
+        actions.iter().for_each(|(to, value)| {
+          println!("@{}  {}:{}", index, to, *value);
+          items[*to].push_front(*value);
+          items[index].pop_back();
+        });
+        items[index].clear();
+      }
+      dbg!(acc.clone());
+      acc
+    });
+    let mut orderly_troup = BinaryHeap::from(rates);
+    let monkey_business =
+      (orderly_troup.pop().unwrap() * orderly_troup.pop().unwrap()) as i32;
+
+    PSSolution { monkey_business }
+  }
+
+  fn output(solution: Self::Solution) {
+    dbg!(solution.monkey_business);
+  }
+}
+
+impl Monkey {
+  fn inspect_items(
+    &mut self,
+    items: &VecDeque<i32>,
+    with_relief: i32,
+  ) -> Vec<(usize, i32)> {
+    let mut actions: Vec<(usize, i32)> = Vec::new();
+    for item in items.iter() {
+      let updated_item = match self.operation.0 {
+        '+' => item + self.operation.1,
+        '*' => {
+          let r = match self.operation.1 {
+            i32::MAX => *item,
+            x => x,
+          };
+          item * r
+        }
+        _ => unimplemented!(),
+      };
+      let updated_item = modular_reduction(updated_item / with_relief).abs();
+      let to = match inv_heaviside(updated_item % self.test) {
+        0 => self.result.0,
+        1 => self.result.1,
+        x => panic!("{}", x),
+      };
+      actions.push((to, updated_item));
+    }
+
+    actions
+  }
+}

--- a/day_11/src/part2.rs
+++ b/day_11/src/part2.rs
@@ -1,0 +1,10 @@
+mod part2_module;
+use part2_module::ProblemSolverPattern;
+mod problem_solver;
+use problem_solver::solve_problem;
+mod common;
+
+
+fn main() {
+  solve_problem::<ProblemSolverPattern>();
+}

--- a/day_11/src/part2_module.rs
+++ b/day_11/src/part2_module.rs
@@ -4,8 +4,7 @@ use super::common::*;
 use super::problem_solver::ProblemSolver;
 
 
-const ROUNDS: usize = 20;
-const RELIEF: i64 = 3;
+const ROUNDS: usize = 10_000;
 
 pub struct PSInput {
   monkeys: Vec<Monkey>,
@@ -36,9 +35,10 @@ impl ProblemSolver for ProblemSolverPattern {
   }
 
   fn solve(input: Self::Input) -> Self::Solution {
+    let lcd: i64 = input.monkeys.iter().map(|m| m.test).product();
     let mut tallies =
       factory_ordered_troup_tallies(input.monkeys, input.items, ROUNDS, |x| {
-        x / RELIEF
+        x % lcd
       });
     let monkey_business =
       (tallies.pop().unwrap() * tallies.pop().unwrap()) as i64;

--- a/day_11/src/problem_solver.rs
+++ b/day_11/src/problem_solver.rs
@@ -1,0 +1,44 @@
+use std::fs::File;
+use std::io::{BufRead, BufReader, Lines};
+use std::path::Path;
+use std::process;
+
+
+pub trait ProblemSolver {
+  type Input;
+  type Solution;
+
+  fn initialize(lines: impl Iterator<Item = String>) -> Self::Input;
+  fn solve(input: Self::Input) -> Self::Solution;
+  fn output(solution: Self::Solution);
+}
+
+pub fn solve_problem<T: ProblemSolver>() {
+  let args: Vec<String> = std::env::args().collect();
+  if args.len() < 2 {
+    eprintln!(
+      "must provide an input file (from context of current working directory)"
+    );
+    process::exit(1);
+  }
+  let input_filename = &args[1];
+  match read_lines(input_filename) {
+    Ok(lines) => {
+      let input = T::initialize(lines.map(|l| l.unwrap()));
+      let solution = T::solve(input);
+      T::output(solution);
+    }
+    Err(err) => {
+      eprintln!("Failed to open input file: {}", err);
+      process::exit(1);
+    }
+  }
+}
+
+fn read_lines<P>(filename: P) -> std::io::Result<Lines<BufReader<File>>>
+where
+  P: AsRef<Path>,
+{
+  let file = File::open(filename)?;
+  Ok(BufReader::new(file).lines())
+}

--- a/day_11/src/problem_solver_main_pattern.rs
+++ b/day_11/src/problem_solver_main_pattern.rs
@@ -1,0 +1,9 @@
+mod problem_solver_module_pattern;
+use problem_solver_module_pattern::ProblemSolverPattern;
+mod problem_solver;
+use problem_solver::solve_problem;
+
+
+fn main() {
+  solve_problem::<ProblemSolverPattern>();
+}

--- a/day_11/src/problem_solver_module_pattern.rs
+++ b/day_11/src/problem_solver_module_pattern.rs
@@ -1,0 +1,31 @@
+use super::problem_solver::ProblemSolver;
+
+
+pub struct PSInput {
+  // Define the structure of input data for the problem
+}
+
+pub struct PSSolution {
+  // Define the structure of the problem solution
+}
+
+pub struct ProblemSolverPattern;
+
+impl ProblemSolver for ProblemSolverPattern {
+  type Input = PSInput;
+  type Solution = PSSolution;
+
+  fn initialize(lines: impl Iterator<Item = String>) -> Self::Input {
+    /* Implement initialization logic to prepare the input to this
+    solver */
+    unimplemented!()
+  }
+
+  fn solve(input: Self::Input) -> Self::Solution {
+    unimplemented!() // Implement logic to solve this problem
+  }
+
+  fn output(solution: Self::Solution) {
+    unimplemented!() // Implement output logic specific to this problem
+  }
+}


### PR DESCRIPTION
I must have gotten lucky in part 1 with modular arithmetic. In the first commit you can see I was using logic because of overflows in i32. that worked for 20 rounds in pt 1, but the same logic fails when we are not floor_dividing by 3, because I had to use an lcd modulus. I'm curious why, since floor dividing makes it hard to reason about. That code is in the pt 1 commit that should be preserved in the history, just before the commit that is in this pr. 

Also, an interesting find, my first hope was I could just change the division from / 3 to / 1, since relief was set in the part modules. but I **got different results** when removing the  / 1 than when including it. Found debugging my wrong results :)